### PR TITLE
Round trip circuit

### DIFF
--- a/Circuit.js
+++ b/Circuit.js
@@ -19,3 +19,34 @@
       ]
 
 */
+
+const pegjs = require("pegjs")
+const fs = require("fs")
+const util = require("util")
+
+let data = ''
+try {
+  data = fs.readFileSync("./parser/qcircuit.pegjs", "utf8")
+} catch (err) {
+  console.error(err)
+}
+const parser = pegjs.generate(data);
+
+function QCircuit([circuitString]) {
+  return parser.parse(circuitString)
+}
+
+function circuitToString(qubits) {
+  const renderPart = part => {
+    switch(part.type) {
+    case "wire": return "-".repeat(part.width)
+    case "gate": return part.name
+    case "cnot": return {target: "*", control: "O", passthrough: "|"}[part.role]
+    case "measure": return "M>"
+    }
+    throw "Part not implemented."
+  }
+  return qubits.map(qubit =>
+    `|${qubit.basis}>${qubit.parts.map(part => renderPart(part)).join("")}`
+  ).join("\n")
+}

--- a/parser/qcircuit.pegjs
+++ b/parser/qcircuit.pegjs
@@ -10,7 +10,7 @@
 */
 
 QCircuit
-  = qubits:Qubits { return qubits }
+  = "\n"* qubits:Qubits { return qubits }
 
 Qubits
   = head:Qubit "\n"* rest:Qubits? { return [head, ...(rest ? rest : [])] }


### PR DESCRIPTION
This PR adds an implementation of `QCircuit` tagged template strings (using the pegjs parser) & a method to convert them to strings, `circuitToString`.